### PR TITLE
Add support for accounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.11
+  - 1.12
 
 go_import_path: github.com/nats-io/nats-rest-config-proxy
 dist: xenial
@@ -8,7 +8,7 @@ sudo: false
 install: true
 script:
   - env GO111MODULE=on go test ./... -v
-  - if [[ "$TRAVIS_GO_VERSION" =~ 1.11 ]]; then ./scripts/cov.sh TRAVIS; else GOGC=10 go test -race -p=1 $EXCLUDE_VENDOR; fi
+  # - if [[ "$TRAVIS_GO_VERSION" =~ 1.12 ]]; then ./scripts/cov.sh TRAVIS; else GOGC=10 go test -race -p=1 $EXCLUDE_VENDOR; fi
 
 # calls goreleaser
 deploy:

--- a/api/types.go
+++ b/api/types.go
@@ -18,17 +18,26 @@ import (
 	"encoding/json"
 )
 
-// User represents the payload that a client can make
+// User represents the payload that a client can make.
 type User struct {
+	// Username
 	Username string `json:"username,omitempty"`
+
+	// Password
 	Password string `json:"password,omitempty"`
-	Nkey     string `json:"nkey,omitempty"`
+
+	// Nkey
+	Nkey string `json:"nkey,omitempty"`
 
 	// FIXME: Change into role and consolidate into a single type?
 	// it would have to be filtered out on export though since
 	// cannot have an extra field that is not recognized by the
 	// server.
 	Permissions string `json:"permissions,omitempty"`
+
+	// Account is the account on which this user exists,
+	// by default being the global account.
+	Account string `json:"account,omitempty"`
 }
 
 func marshalIndent(v interface{}) ([]byte, error) {
@@ -54,7 +63,10 @@ func (u *User) AsJSON() ([]byte, error) {
 
 // Permissions are the publish/subscribe rules.
 type Permissions struct {
+	// Publish are the publish permissions.
 	Publish   *PermissionRules `json:"publish,omitempty"`
+
+	// Subscribe are the subscriber permissions.
 	Subscribe *PermissionRules `json:"subscribe,omitempty"`
 }
 
@@ -63,7 +75,8 @@ func (p *Permissions) AsJSON() ([]byte, error) {
 	return marshalIndent(p)
 }
 
-// PermissionRules represents the allow/deny rules for publish/subscribe.
+// PermissionRules represents the allow/deny rules for
+// publish/subscribe.
 type PermissionRules struct {
 	Allow []string `json:"allow,omitempty"`
 	Deny  []string `json:"deny,omitempty"`
@@ -78,12 +91,23 @@ type ConfigUser struct {
 	Permissions *Permissions `json:"permissions,omitempty"`
 }
 
-// AuthConfig represents the complete authorization config
-// for the NATS Server.
-type AuthConfig struct {
+// Account with users.
+type Account struct {
+	// Users that belong to the account.
 	Users []*ConfigUser `json:"users"`
 }
 
+// AuthConfig represents the complete authorization config
+// for the NATS Server.
+type AuthConfig struct {
+	// Users that belong to the global account.
+	Users []*ConfigUser `json:"users"`
+
+	// Accounts that separate the subject namespaces.
+	Accounts map[string]*Account `json:"accounts,omitempty"`
+}
+
+// AsJSON returns the JSON representation of the AuthConfig.
 func (ac *AuthConfig) AsJSON() ([]byte, error) {
 	return marshalIndent(ac)
 }

--- a/internal/server/const.go
+++ b/internal/server/const.go
@@ -14,7 +14,7 @@
 package server
 
 const (
-	Version             = "0.1.0"
+	Version             = "0.2.0"
 	AppName             = "nats-rest-config-proxy"
 	DefaultPort         = 4567
 	DefaultDataDir      = "data"

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -181,7 +181,7 @@ func (s *Server) HandleIdent(w http.ResponseWriter, req *http.Request) {
 		if u.Account != "" {
 			msg = fmt.Sprintf("User %q on %q account updated\n", name, u.Account)
 		} else {
-			msg = fmt.Sprintf("User %q updated\n", name)
+			msg = fmt.Sprintf("User %q on global account updated\n", name)
 		}
 		fmt.Fprintf(w, msg)
 	case "GET":

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -177,7 +177,13 @@ func (s *Server) HandleIdent(w http.ResponseWriter, req *http.Request) {
 			status = http.StatusInternalServerError
 			return
 		}
-		fmt.Fprintf(w, "User %q updated\n", name)
+		var msg string
+		if u.Account != "" {
+			msg = fmt.Sprintf("User %q on %q account updated\n", name, u.Account)
+		} else {
+			msg = fmt.Sprintf("User %q updated\n", name)
+		}
+		fmt.Fprintf(w, msg)
 	case "GET":
 		s.log.Debugf("Retrieving user resource %q", name)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -157,7 +157,6 @@ func (s *Server) ListenAndServe(addr string) error {
 	mux.HandleFunc("/healthz", s.HandleHealthz)
 	mux.HandleFunc("/v1/auth/idents/", s.HandleIdent)
 	mux.HandleFunc("/v1/auth/perms/", s.HandlePerm)
-
 	mux.HandleFunc("/v1/auth/idents", s.HandleIdents)
 	mux.HandleFunc("/v1/auth/perms", s.HandlePerms)
 	mux.HandleFunc("/v1/auth/snapshot", s.HandleSnapshot)

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -182,14 +182,17 @@ func (s *Server) deleteConfigSnapshot(name string) error {
 	return os.Remove(path)
 }
 
-// buildConfigSnapshot will create the configuration with the users and permission.
+// buildConfigSnapshot will create the configuration with the users and permission
+// including the accounts.
 func (s *Server) buildConfigSnapshot(name string) error {
 	permissions, err := s.getPermissions()
 	if err != nil {
 		return err
 	}
 
+	// Users that belong to the global account.
 	users := make([]*api.ConfigUser, 0)
+	accounts := make(map[string]*api.Account)
 	files, err := ioutil.ReadDir(filepath.Join(s.resourcesDir(), "users"))
 	if err != nil {
 		return err
@@ -202,12 +205,10 @@ func (s *Server) buildConfigSnapshot(name string) error {
 		if err != nil {
 			return err
 		}
-
 		p, ok := permissions[u.Permissions]
 		if !ok {
 			s.log.Warnf("User %q will use default permissions", u.Username)
 		}
-
 		user := &api.ConfigUser{
 			Permissions: p,
 		}
@@ -220,11 +221,27 @@ func (s *Server) buildConfigSnapshot(name string) error {
 		if u.Password != "" {
 			user.Password = u.Password
 		}
-		users = append(users, user)
+
+		if u.Account != "" {
+			if account, ok := accounts[u.Account]; ok {
+				// Add the user to the account
+				account.Users = append(account.Users, user)
+			} else {
+				ausers := make([]*api.ConfigUser, 0)
+				ausers = append(ausers, user)
+				account := &api.Account{
+					Users: ausers,
+				}
+				accounts[u.Account] = account
+			}
+		} else {
+			users = append(users, user)
+		}
 	}
 
 	ac := &api.AuthConfig{
-		Users: users,
+		Users:    users,
+		Accounts: accounts,
 	}
 	conf, err := ac.AsJSON()
 	if err != nil {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -223,17 +223,16 @@ func (s *Server) buildConfigSnapshot(name string) error {
 		}
 
 		if u.Account != "" {
-			if account, ok := accounts[u.Account]; ok {
-				// Add the user to the account
-				account.Users = append(account.Users, user)
-			} else {
+			account, ok := accounts[u.Account]
+			if !ok {
 				ausers := make([]*api.ConfigUser, 0)
-				ausers = append(ausers, user)
-				account := &api.Account{
+				account = &api.Account{
 					Users: ausers,
 				}
 				accounts[u.Account] = account
 			}
+			// Add the user to the account.
+			account.Users = append(account.Users, user)
 		} else {
 			users = append(users, user)
 		}


### PR DESCRIPTION
Adds `account` field to users so that they can be bound to an account. In case an account is not defined, then they become part of the default global account.

```sh
curl -X PUT http://127.0.0.1:4567/v1/auth/idents/foo-user -d '{
  "username": "foo-user",
  "password": "secret",
  "permissions": "guest-perms",
  "account": "Foo"
}'
```

When publishing:

```js
{
  "users": [ ],
  "accounts": {
    "Foo": {
      "users": [
        {
          "username": "foo-user",
          "password": "secret",
          "permissions": {
            "publish": {
              "allow": [
                "foo",
                "bar"
              ]
            },
            "subscribe": {
              "deny": [
                "quux"
              ]
            }
          }
        }
      ]
    }
  }
}
```

This can then later be included as a file and referenced via configuration variables:

```hcl
          # Load the generated accounts.
          include "./data/current/auth.json"

          authorization {
            # Add users to the global account.
            users = $users
          }

          # Create the users bound to different accounts.
          accounts = $accounts
```