### PR TITLE
Add new v2 snapshot/publish endpoint

### DIFF
--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1241,7 +1241,7 @@ func TestAccountsHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(s.opts.DataDir)
+	// defer os.RemoveAll(s.opts.DataDir)
 
 	ctx, done := context.WithTimeout(context.Background(), 2*time.Second)
 	defer done()
@@ -1580,4 +1580,13 @@ func TestAccountsHandler(t *testing.T) {
 			t.Errorf("Expected: %+v\nGot: %+v", expected, got)
 		}
 	})
+
+	// Publish with the new structure		
+	resp, _, err := curl("POST", host+"/v2/auth/publish", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected OK, got: %v", resp.StatusCode)
+	}
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1241,7 +1241,7 @@ func TestAccountsHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// defer os.RemoveAll(s.opts.DataDir)
+	defer os.RemoveAll(s.opts.DataDir)
 
 	ctx, done := context.WithTimeout(context.Background(), 2*time.Second)
 	defer done()
@@ -1405,16 +1405,23 @@ func TestAccountsHandler(t *testing.T) {
 
 	// Create a user in each of the accounts.
 	t.Run("publishing with multiple users using v1 endpoint", func(t *testing.T) {
-		accounts := []string{"foo", "bar", "quux", "quuz"}
+		accounts := []string{"foo", "bar", "quux", "quuz", ""}
 		for _, acc := range accounts {
+			var username string
+			if acc == "" {
+				username = "global-user"
+			} else {
+				username = fmt.Sprintf("%s-user", acc)
+			}
+
 			payload := `{
-                          "username": "%s-user",
+                          "username": "%s",
                           "password": "secret",
                           "account": "%s"
                         }`
-			payload = fmt.Sprintf(payload, acc, acc)
+			payload = fmt.Sprintf(payload, username, acc)
 
-			endpoint := fmt.Sprintf("%s/v1/auth/idents/%s-user", host, acc)
+			endpoint := fmt.Sprintf("%s/v1/auth/idents/%s", host, username)
 			resp, _, err := curl("PUT", endpoint, []byte(payload))
 			if err != nil {
 				t.Fatal(err)
@@ -1449,7 +1456,12 @@ func TestAccountsHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		expected := `{
-  "users": [],
+  "users": [
+    {
+      "username": "global-user",
+      "password": "secret"
+    }
+  ],
   "accounts": {
     "bar": {
       "users": [
@@ -1581,8 +1593,32 @@ func TestAccountsHandler(t *testing.T) {
 		}
 	})
 
-	// Publish with the new structure		
-	resp, _, err := curl("POST", host+"/v2/auth/publish", []byte(""))
+	// Publish and snapshot with the new structure
+	resp, _, err := curl("POST", host+"/v2/auth/snapshot?name=new", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	resp, _, err = curl("POST", host+"/v2/auth/publish?name=new", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	resp, _, err = curl("DELETE", host+"/v2/auth/snapshot?name=new", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	resp, _, err = curl("POST", host+"/v2/auth/publish", []byte(""))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -165,6 +165,8 @@ func (s *Server) ListenAndServe(addr string) error {
 	mux.HandleFunc("/v1/auth/publish/", s.HandlePublish)
 	mux.HandleFunc("/v1/auth/accounts", s.HandleAccounts)
 	mux.HandleFunc("/v1/auth/accounts/", s.HandleAccounts)
+	mux.HandleFunc("/v2/auth/publish", s.HandlePublishV2)
+	mux.HandleFunc("/v2/auth/publish/", s.HandlePublishV2)
 	srv := &http.Server{
 		Addr:           addr,
 		Handler:        mux,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -165,6 +165,8 @@ func (s *Server) ListenAndServe(addr string) error {
 	mux.HandleFunc("/v1/auth/publish/", s.HandlePublish)
 	mux.HandleFunc("/v1/auth/accounts", s.HandleAccounts)
 	mux.HandleFunc("/v1/auth/accounts/", s.HandleAccounts)
+	mux.HandleFunc("/v2/auth/snapshot", s.HandleSnapshotV2)
+	mux.HandleFunc("/v2/auth/snapshot/", s.HandleSnapshotV2)
 	mux.HandleFunc("/v2/auth/publish", s.HandlePublishV2)
 	mux.HandleFunc("/v2/auth/publish/", s.HandlePublishV2)
 	srv := &http.Server{


### PR DESCRIPTION
This endpoint works the same as the `v1` endpoint, but splits the accounts into its own files, making it easier to manage. For example:

```sh
acl-proxy-data-dir/
├── current
│   ├── accounts
│   │   ├── auth.conf
│   │   ├── bar.json
│   │   ├── foo.json
│   │   ├── global.json
│   │   ├── quux.json
│   │   └── quuz.json
│   └── auth.json
├── resources
│   ├── accounts
│   │   ├── bar.json
│   │   ├── foo.json
│   │   ├── quux.json
│   │   └── quuz.json
│   ├── permissions
│   └── users
│       ├── bar-user.json
│       ├── foo-user.json
│       ├── global-user.json
│       ├── quux-user.json
│       └── quuz-user.json
└── snapshots
    ├── latest #v2 style published config (now a directory split into files)
    │   ├── auth.conf
    │   ├── bar.json
    │   ├── foo.json
    │   ├── global.json
    │   ├── quux.json
    │   └── quuz.json
    └── v1.json # v1 style published config
```

A user can then include the authorization config 

```
include "config/current/accounts/auth.conf"
```

And optionally include users in the global accounts (users that were created that do no not belong to an account) too if needed:

```
authorization  {
  include "config/current/accounts/global.json"
}
```