### PR TITLE
Release v0.4.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,8 @@ release:
   name_template: 'Release {{.Tag}}'
 
 builds:
--
+- id: nats-rest-config-proxy
+  main: ./cmd/nats-rest-config-proxy/main.go
   ldflags: -s -w
   binary: nats-rest-config-proxy
   env:
@@ -31,16 +32,30 @@ builds:
   ignore:
   - goos: darwin
     goarch: 386
+- id: nats-rest-config-validator
+  main: ./cmd/nats-rest-config-validator/main.go
+  ldflags: -s -w
+  binary: nats-rest-config-validator
+  env:
+    - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - 386
+  - amd64
+  - arm
+  - arm64
+  goarm:
+  - 6
+  - 7
+  ignore:
+  - goos: darwin
+    goarch: 386
 
-
-archive:
- # replacements:
- #   darwin: Darwin
- #   linux: Linux
- #   windows: Windows
- #   386: 386
- #   amd64: x86_64
-  wrap_in_directory: true
+archives:
+- wrap_in_directory: true
   name_template: '{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm
     }}v{{ .Arm }}{{ end }}'
   format: zip
@@ -62,8 +77,8 @@ changelog:
 github_urls:
   download: https://github.com
 
-nfpm:
-  formats:
+nfpms:
+- formats:
     - deb
   name_template: '{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm
     }}v{{ .Arm }}{{ end }}'

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=


### PR DESCRIPTION
### Added

- Added `nats-rest-config-validator` that supports out of band validation without starting the server

### Fixed

- Fixed validation issue with exported services

Signed-off-by: Waldemar Quevedo <wally@synadia.com>