### PR TITLE
Fix publishing snapshots

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,48 @@ builds:
   ignore:
   - goos: darwin
     goarch: 386
+- id: nats-rest-config-publish
+  main: ./cmd/nats-rest-config-publish/main.go
+  ldflags: -s -w
+  binary: nats-rest-config-publish
+  env:
+    - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - 386
+  - amd64
+  - arm
+  - arm64
+  goarm:
+  - 6
+  - 7
+  ignore:
+  - goos: darwin
+    goarch: 386
+- id: nats-rest-config-snapshot
+  main: ./cmd/nats-rest-config-snapshot/main.go
+  ldflags: -s -w
+  binary: nats-rest-config-snapshot
+  env:
+    - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - 386
+  - amd64
+  - arm
+  - arm64
+  goarm:
+  - 6
+  - 7
+  ignore:
+  - goos: darwin
+    goarch: 386
 
 archives:
 - wrap_in_directory: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.12
+  - 1.14
 
 go_import_path: github.com/nats-io/nats-rest-config-proxy
 dist: xenial
@@ -8,7 +8,7 @@ sudo: false
 install: true
 script:
   - env GO111MODULE=on go test ./... -v
-  - if [[ "$TRAVIS_GO_VERSION" =~ 1.12 ]]; then ./scripts/cov.sh TRAVIS; else GOGC=10 go test -race -p=1 $EXCLUDE_VENDOR; fi
+  - if [[ "$TRAVIS_GO_VERSION" =~ 1.14 ]]; then ./scripts/cov.sh TRAVIS; else GOGC=10 go test -race -p=1 $EXCLUDE_VENDOR; fi
 
 # calls goreleaser
 deploy:

--- a/cmd/nats-rest-config-publish/main.go
+++ b/cmd/nats-rest-config-publish/main.go
@@ -42,8 +42,8 @@ func main() {
 	flag.StringVar(&opts.DataDir, "data", ".", "Directory for storing data.")
 	flag.StringVar(&opts.DataDir, "dir", ".", "Directory for storing data.")
 	flag.StringVar(&opts.DataDir, "d", ".", "Directory for storing data.")
-	flag.StringVar(&snapshotName, "s", ".", "Snapshot of the configuration.")
-	flag.StringVar(&snapshotName, "snapshot", ".", "Snapshot of the configuration.")
+	flag.StringVar(&snapshotName, "s", "", "Snapshot of the configuration.")
+	flag.StringVar(&snapshotName, "snapshot", "", "Snapshot of the configuration.")
 	flag.StringVar(&publishScript, "f", "", "Path to an optional script to execute on publish")
 	flag.StringVar(&publishScript, "publish-script", "", "Path to an optional script to execute on publish")
 	flag.BoolVar(&showVersion, "v", false, "Show version.")
@@ -65,11 +65,15 @@ func main() {
 
 	if snapshotName == "" {
 		snapshotName = server.DefaultSnapshotName
+
+		// Publish latest config as is taking a snapshot too.
+		fmt.Printf("Taking %q snapshot...\n", snapshotName)
+		if err := s.TakeSnapshot(snapshotName); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+			os.Exit(1)
+		}
 	}
-	if err := s.TakeSnapshot(snapshotName); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
-	}
+	fmt.Printf("Publishing %q snapshot\n", snapshotName)
 	if err := s.PublishSnapshot(snapshotName); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)

--- a/cmd/nats-rest-config-publish/main.go
+++ b/cmd/nats-rest-config-publish/main.go
@@ -15,8 +15,8 @@ import (
 
 const usageStr = `
 Options:
-    -d, --dir <directory>         Directory for storing data (default is the current directory.)
-    -s, --snapshot <name>         Take snapshot of the configuration
+    -d, --dir <directory>         Directory for storing data (default: current directory.)
+    -s, --snapshot <name>         Snapshot of the configuration (default: latest configuration).
     -h, --help                    Show this message
     -v, --version                 Show version
 `
@@ -25,7 +25,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage: nats-rest-config-snapshot [options...]")
+		fmt.Fprintln(os.Stderr, "Usage: nats-rest-config-publish [options...]")
 		fmt.Fprintln(os.Stderr, usageStr)
 	}
 
@@ -42,8 +42,8 @@ func main() {
 	flag.StringVar(&opts.DataDir, "data", ".", "Directory for storing data.")
 	flag.StringVar(&opts.DataDir, "dir", ".", "Directory for storing data.")
 	flag.StringVar(&opts.DataDir, "d", ".", "Directory for storing data.")
-	flag.StringVar(&snapshotName, "s", "", "Snapshot of the configuration.")
-	flag.StringVar(&snapshotName, "snapshot", "", "Snapshot of the configuration.")
+	flag.StringVar(&snapshotName, "s", "", "Snapshot of the configuration (default: latest configuration).")
+	flag.StringVar(&snapshotName, "snapshot", "", "Snapshot of the configuration (default: latest configuration).")
 	flag.StringVar(&publishScript, "f", "", "Path to an optional script to execute on publish")
 	flag.StringVar(&publishScript, "publish-script", "", "Path to an optional script to execute on publish")
 	flag.BoolVar(&showVersion, "v", false, "Show version.")

--- a/cmd/nats-rest-config-snapshot/main.go
+++ b/cmd/nats-rest-config-snapshot/main.go
@@ -38,8 +38,8 @@ func main() {
 	flag.StringVar(&opts.DataDir, "data", ".", "Directory for storing data.")
 	flag.StringVar(&opts.DataDir, "dir", ".", "Directory for storing data.")
 	flag.StringVar(&opts.DataDir, "d", ".", "Directory for storing data.")
-	flag.StringVar(&snapshotName, "s", ".", "Snapshot of the configuration.")
-	flag.StringVar(&snapshotName, "snapshot", ".", "Snapshot of the configuration.")
+	flag.StringVar(&snapshotName, "s", server.DefaultSnapshotName, "Snapshot of the configuration.")
+	flag.StringVar(&snapshotName, "snapshot", server.DefaultSnapshotName, "Snapshot of the configuration.")
 	flag.BoolVar(&showVersion, "v", false, "Show version.")
 	flag.BoolVar(&showVersion, "version", false, "Show version.")
 	flag.BoolVar(&showHelp, "h", false, "Show help.")
@@ -56,6 +56,7 @@ func main() {
 	}
 
 	s := server.NewServer(opts)
+	fmt.Printf("Taking %q snapshot...\n", snapshotName)
 	if err := s.TakeSnapshot(snapshotName); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)

--- a/internal/server/const.go
+++ b/internal/server/const.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 The NATS Authors
+// Copyright 2018-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 package server
 
 const (
-	Version             = "0.4.4"
+	Version             = "0.5.0"
 	AppName             = "nats-rest-config-proxy"
 	DefaultPort         = 4567
 	DefaultDataDir      = "data"

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1944,8 +1944,21 @@ echo 'Publishing script...' > ./artifact2.log
 	host := fmt.Sprintf("http://%s:%d", s.opts.Host, s.opts.Port)
 	createFixtures(t, host)
 
+	resp, rerr, err := curl("POST", host+"/v2/auth/publish?name=foo", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(rerr)
+	expected := "Error: Snapshot named \"foo\" does not exist!\n"
+	if got != expected {
+		t.Fatalf("\nExpected: %v,\n     Got: %v", expected, got)
+	}
+	if resp.StatusCode != 500 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
 	// Publish the config
-	resp, _, err := curl("POST", host+"/v2/auth/publish", []byte(""))
+	resp, _, err = curl("POST", host+"/v2/auth/publish", []byte(""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1958,7 +1971,7 @@ echo 'Publishing script...' > ./artifact2.log
 		t.Fatal(err)
 	}
 
-	expected := `{
+	expected = `{
   "users": [
     {
       "username": "first-user",
@@ -1997,7 +2010,7 @@ echo 'Publishing script...' > ./artifact2.log
   ]
 }
 `
-	got := string(result)
+	got = string(result)
 	if got != expected {
 		t.Errorf("Expected: %q\nGot: %q", expected, got)
 	}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -298,6 +298,9 @@ func (s *Server) getConfigSnapshot(name string) ([]byte, error) {
 // publishConfigSnapshotV2
 func (s *Server) publishConfigSnapshotV2(name string) error {
 	from := filepath.Join(s.snapshotsDir(), name)
+	if _, err := os.Stat(from); err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("Snapshot named %q does not exist!", name)
+	}
 	to := filepath.Join(s.currentConfigDir(), "accounts")
 
 	// First remove the contents of the folder in case there is anything.


### PR DESCRIPTION
The newly added tools for publishing snapshots were always taking a snapshot of latest instead of picking the named snapshot.
Signed-off-by: Waldemar Quevedo <wally@synadia.com>