### PR TITLE
Fix handlers for Idents

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -247,13 +247,19 @@ func verifyIdent(users []*api.User, u *api.User) error {
 			continue
 		}
 
-		if user.Account != u.Account {
-			return fmt.Errorf("%s already exists in different account", u.Username)
+		if len(user.Username) > 0 && user.Account == u.Account {
+			return fmt.Errorf("%s already exists in different account", u.Username )
 		}
-
-		if user.Password != u.Password || user.Nkey != u.Nkey {
-			return fmt.Errorf("conflicting creds for user %s", u.Username)
+		if len(user.Password) > 0 {
+			if user.Password == u.Password {
+				return fmt.Errorf("conflicting password for user %s", u.Username)
 		}
+		}
+		if len(user.Nkey) > 0 {
+			if user.Nkey == u.Nkey {
+				return fmt.Errorf("conflicting Nkey for user %s", u.Username)
+		}
+	}
 	}
 
 	return nil


### PR DESCRIPTION
Checks if Ident is using Username and password as authentication or NKeys (As they do not require having a Username). Tested with these scenarios:

- Adding two users with NKeys. (worked)
- Adding a second user with same Nkey. (Error: conflicting nkeys)
- Adding a second user with same username (Error: already exists in different account)
- Adding a second user in the same account with the same password (Error: conflicting password) (Ps: I am not sure why users can't have the same password, but feel free to delete it, I left it, as it already was there)