### PR TITLE
Add nats-rest-config-fix tool

### DIFF
--- a/cmd/nats-rest-config-fix/README.md
+++ b/cmd/nats-rest-config-fix/README.md
@@ -1,0 +1,15 @@
+# NATS REST Configuration Fix Tool
+
+This tool can repair a data directory that may have issues like deduping equivalent entries.
+
+## Usage
+
+```
+Usage: nats-rest-config-fix [options...]
+
+Options:
+    -d, --dir <directory>         Directory for storing data
+    -h, --help                    Show this message
+    -v, --version                 Show version
+
+```

--- a/cmd/nats-rest-config-fix/main.go
+++ b/cmd/nats-rest-config-fix/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats-rest-config-proxy/internal/server"
+)
+
+const usageStr = `
+Options:
+    -d, --dir <directory>         Directory for storing data (default is the current directory.)
+    -h, --help                    Show this message
+    -v, --version                 Show version`
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: nats-rest-config-fix [options...]")
+		fmt.Fprintln(os.Stderr, usageStr)
+	}
+
+	var (
+		showVersion   bool
+		showHelp      bool
+		debugAndTrace bool
+	)
+
+	opts := &server.Options{}
+	flag.StringVar(&opts.DataDir, "data", ".", "Directory for storing data.")
+	flag.StringVar(&opts.DataDir, "dir", ".", "Directory for storing data.")
+	flag.StringVar(&opts.DataDir, "d", ".", "Directory for storing data.")
+	flag.BoolVar(&showVersion, "v", false, "Show version.")
+	flag.BoolVar(&showVersion, "version", false, "Show version.")
+	flag.BoolVar(&showHelp, "h", false, "Show help.")
+	flag.BoolVar(&showHelp, "help", false, "Show help.")
+	flag.BoolVar(&opts.Debug, "D", false, "Show debug logs.")
+	flag.BoolVar(&opts.Trace, "V", false, "Show trace logs.")
+	flag.BoolVar(&debugAndTrace, "DV", false, "Show debug and trace logs.")
+	flag.Parse()
+
+	switch {
+	case showHelp:
+		flag.Usage()
+		os.Exit(0)
+	case showVersion:
+		fmt.Printf("nats-rest-config-fix %s\n", server.Version)
+		os.Exit(0)
+	}
+	if debugAndTrace {
+		opts.Debug = true
+		opts.Trace = true
+	}
+
+	s := server.NewServer(opts)
+	if err := s.RunDataDirectoryRepair(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintln(os.Stderr, "OK")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/nats-io/nats-rest-config-proxy
 go 1.19
 
 require (
-	github.com/nats-io/nats-server/v2 v2.9.7
+	github.com/nats-io/nats-server/v2 v2.9.8
 	github.com/nats-io/nats.go v1.20.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/nats-io/jwt/v2 v2.3.0 h1:z2mA1a7tIf5ShggOFlR1oBPgd6hGqcDYsISxZByUzdI=
 github.com/nats-io/jwt/v2 v2.3.0/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
-github.com/nats-io/nats-server/v2 v2.9.7 h1:VBlfq7xvv/72v0mzGZ2rgsDzUoVyX2Xhssl9XpKDue0=
-github.com/nats-io/nats-server/v2 v2.9.7/go.mod h1:AB6hAnGZDlYfqb7CTAm66ZKMZy9DpfierY1/PbpvI2g=
+github.com/nats-io/nats-server/v2 v2.9.8 h1:jgxZsv+A3Reb3MgwxaINcNq/za8xZInKhDg9Q0cGN1o=
+github.com/nats-io/nats-server/v2 v2.9.8/go.mod h1:AB6hAnGZDlYfqb7CTAm66ZKMZy9DpfierY1/PbpvI2g=
 github.com/nats-io/nats.go v1.20.0 h1:T8JJnQfVSdh1CzGiwAOv5hEobYCBho/0EupGznYw0oM=
 github.com/nats-io/nats.go v1.20.0/go.mod h1:tLqubohF7t4z3du1QDPYJIQQyhb4wl6DhjxEajSI7UA=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -1965,3 +1965,455 @@ func TestFullCycleWithAccountsRDNsPermissionsMerge(t *testing.T) {
 		t.Errorf("Expected %q, got: %q", expected, got)
 	}
 }
+
+func TestFullCycleWithAccountsRDNsPermissionsMergeThenRepair(t *testing.T) {
+	// Create a data directory.
+	opts := DefaultOptions()
+	opts.DataDir = "./data-accounts-rdns-merge-then-repair"
+	s := server.NewServer(opts)
+	host := fmt.Sprintf("http://%s:%d", opts.Host, opts.Port)
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	time.AfterFunc(2*time.Second, func() {
+		s.Shutdown(ctx)
+		waitServerIsDone(t, ctx, host)
+	})
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		done <- struct{}{}
+	}()
+	waitServerIsReady(t, ctx, host)
+
+	// Need to create the accounts first, use an empty JSON payload to create them.
+	resp, _, err := curl("PUT", host+"/v1/auth/accounts/foo", []byte("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+	resp, _, err = curl("PUT", host+"/v1/auth/accounts/bar", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+	resp, _, err = curl("PUT", host+"/v1/auth/accounts/fizz", []byte("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	resp, _, err = curl("GET", host+"/v1/auth/accounts/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	// Get all created accounts.
+	resp, body, err := curl("GET", host+"/v1/auth/accounts/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+	var accsBody []interface{}
+	if err := json.Unmarshal(body, &accsBody); err != nil {
+		t.Fatal(err)
+	}
+	if len(accsBody) != 3 {
+		t.Fatalf("Expected 3 accounts, got: %v", len(accsBody))
+	}
+
+	// Create the permissions.
+	payload := `{
+         "publish": {
+           "allow": ["foo", "bar"]
+          },
+          "subscribe": {
+            "deny": ["quux"]
+          }
+	}`
+	resp, _, err = curl("PUT", host+"/v1/auth/perms/normal-user", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	// Merge the permissions from multiple users.
+	payload = `{
+         "publish": {
+           "allow": ["quuz"]
+          }
+	}`
+	resp, _, err = curl("PUT", host+"/v1/auth/perms/extended-user", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	// Create a couple of users.
+	payload = `{
+	  "username": "CN=pubsub.nats.acme.int,O=Acme,OU=Foo,L=Los Angeles,ST=California,C=US",
+	  "permissions": "normal-user",
+	  "account": "foo"
+	}`
+	resp, _, err = curl("PUT", host+"/v1/auth/idents/foo-user", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	// Same user but with different permissions, they will be merged.
+	payload = `{
+	  "username": "CN=pubsub.nats.acme.int,OU=Foo,O=Acme,L=Los Angeles,ST=California,C=US",
+          "permissions": "extended-user",
+          "account": "foo"
+	}`
+	resp, _, err = curl("PUT", host+"/v1/auth/idents/bar-user", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	payload = `{
+	  "username": "OU=Foo,O=Acme,L=Los Angeles,ST=California,C=US",
+          "permissions": "normal-user"
+	}`
+	resp, _, err = curl("PUT", host+"/v1/auth/idents/global-user", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	resp, _, err = curl("POST", host+"/v2/auth/validate", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	// Publish a named snapshot.
+	resp, body, err = curl("POST", host+"/v2/auth/publish", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected OK, got: %v", resp.StatusCode)
+	}
+
+	// Write a config file with repeated equivalent entries.
+	data := `
+{
+  "users": [
+    {
+      "username": "CN=pubsub.nats.acme.int,OU=Foo,O=Acme,L=Los Angeles,ST=California,C=US",
+      "permissions": {
+        "publish": {
+          "allow": [
+            "bar",
+            "foo",
+            "quuz"
+          ]
+        },
+        "subscribe": {
+          "deny": [
+            "quux"
+          ]
+        }
+      }
+    },
+    {
+      "username": "CN=pubsub.nats.acme.int,O=Acme,OU=Foo,L=Los Angeles,ST=California,C=US",
+      "permissions": {
+        "publish": {
+          "allow": [
+            "bar.1",
+            "foo.2",
+            "quuz.3"
+          ]
+        },
+        "subscribe": {
+          "deny": [
+            "quux"
+          ]
+        }
+      }
+    },
+    {
+      "username": "CN=pubsub.nats.acme.int,L=Los Angeles,O=Acme,OU=Foo,ST=California,C=US",
+      "permissions": {
+        "publish": {
+          "allow": [
+            "bar.1",
+            "foo.2",
+            "quuz.3"
+          ]
+        },
+        "subscribe": {
+          "deny": [
+            "quux.2",
+            "quux.3"
+          ]
+        }
+      }
+    }
+  ]
+}
+`
+	dataDir := filepath.Join(opts.DataDir, "current", "accounts")
+	err = os.WriteFile(filepath.Join(dataDir, "foo.json"), []byte(data), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sopts := DefaultOptions()
+	sopts.DataDir = dataDir
+	s2 := server.NewServer(sopts)
+	if err := s2.RunDataDirectoryRepair(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := os.ReadFile(filepath.Join(dataDir, "foo.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{
+  "users": [
+    {
+      "username": "CN=pubsub.nats.acme.int,OU=Foo,O=Acme,L=Los Angeles,ST=California,C=US",
+      "permissions": {
+        "publish": {
+          "allow": [
+            "bar",
+            "bar.1",
+            "foo",
+            "foo.2",
+            "quuz",
+            "quuz.3"
+          ]
+        },
+        "subscribe": {
+          "deny": [
+            "quux",
+            "quux.2",
+            "quux.3"
+          ]
+        }
+      }
+    }
+  ]
+}
+`
+	if string(result) != expected {
+		t.Fatalf("Got %q, expected: %q", result, expected)
+	}
+
+	// Now start a server with the config.
+	config := `
+          tls {
+            ca_file = "./certs/rdns/ca.pem"
+            cert_file = "./certs/rdns/client-4222.pem"
+            key_file = "./certs/rdns/client-4222.key"
+            verify_and_map = true
+          }
+          debug = true
+          trace = true
+
+          authorization {
+            include "accounts/global.json"
+          }
+
+          # Load the generated accounts.
+          include "accounts/auth.conf"
+        `
+
+	err = ioutil.WriteFile(filepath.Join(opts.DataDir, "current", "main.conf"), []byte(config), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	natsd, _ := gnatsd.RunServerWithConfig(filepath.Join(opts.DataDir, "current", "main.conf"))
+	if natsd == nil {
+		t.Fatal("Unexpected error starting a configured NATS server")
+	}
+	defer natsd.Shutdown()
+
+	errCh := make(chan error, 2)
+	ncA, err := nats.Connect("tls://localhost:4222",
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			errCh <- err
+		}),
+		nats.RootCAs("./certs/rdns/ca.pem"),
+		nats.ClientCert("./certs/rdns/client-A.pem", "./certs/rdns/client-A.key"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ncA.Close()
+
+	ncB, err := nats.Connect("nats://localhost:4222",
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			errCh <- err
+		}),
+		nats.RootCAs("./certs/rdns/ca.pem"),
+		nats.ClientCert("./certs/rdns/client-B.pem", "./certs/rdns/client-B.key"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ncB.Flush()
+	defer ncB.Close()
+
+	subA, err := ncA.SubscribeSync(">")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ncA.Publish("foo", []byte("hello"))
+	ncA.Publish("bar", []byte("hello"))
+	ncA.Publish("quuz", []byte("hello"))
+	ncA.Flush()
+
+	msg, err := subA.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	got := msg.Subject
+	expected = "foo"
+	if got != expected {
+		t.Errorf("Expected %q, got: %q", expected, got)
+	}
+
+	msg, err = subA.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	got = msg.Subject
+	expected = "bar"
+	if got != expected {
+		t.Errorf("Expected %q, got: %q", expected, got)
+	}
+
+	msg, err = subA.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	got = msg.Subject
+	expected = "quuz"
+	if got != expected {
+		t.Errorf("Expected %q, got: %q", expected, got)
+	}
+
+	subB, err := ncB.SubscribeSync(">")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ncB.Publish("foo", []byte("hello"))
+	ncB.Publish("bar", []byte("hello"))
+	ncB.Publish("quuz", []byte("hello"))
+	ncB.Flush()
+	msg, err = subB.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	got = msg.Subject
+	expected = "foo"
+	if got != expected {
+		t.Errorf("Expected %q, got: %q", expected, got)
+	}
+
+	msg, err = subB.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	got = msg.Subject
+	expected = "bar"
+	if got != expected {
+		t.Errorf("Expected %q, got: %q", expected, got)
+	}
+
+	msg, err = subB.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	got = msg.Subject
+	expected = "quuz"
+	if got != expected {
+		t.Errorf("Expected %q, got: %q", expected, got)
+	}
+
+	ncA.Publish("denied-to-A", []byte("hello"))
+	time.Sleep(500 * time.Millisecond)
+	ncB.Publish("denied-to-B", []byte("hello"))
+
+	select {
+	case err := <-errCh:
+		got := err.Error()
+		expected := `nats: Permissions Violation for Publish to "denied-to-A"`
+		if got != expected {
+			t.Errorf("Expected %q, got: %q", expected, got)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timed out waiting for error code")
+	}
+
+	select {
+	case err := <-errCh:
+		got := err.Error()
+		expected := `nats: Permissions Violation for Publish to "denied-to-B"`
+		if got != expected {
+			t.Errorf("Expected %q, got: %q", expected, got)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timed out waiting for error code")
+	}
+
+	ncC, err := nats.Connect("nats://localhost:4222",
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			errCh <- err
+		}),
+		nats.RootCAs("./certs/rdns/ca.pem"),
+		nats.ClientCert("./certs/rdns/client-C.pem", "./certs/rdns/client-C.key"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ncC.Flush()
+	defer ncC.Close()
+
+	subC, err := ncC.SubscribeSync(">")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ncC.Publish("foo", []byte("hello"))
+	ncC.Publish("bar", []byte("hello"))
+	ncA.Flush()
+
+	msg, err = subC.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	got = msg.Subject
+	expected = "foo"
+	if got != expected {
+		t.Errorf("Expected %q, got: %q", expected, got)
+	}
+}


### PR DESCRIPTION
This adds a `nats-rest-config-fix` command that can be used to find DN duplicates in a config.