### PR TITLE
Add Subject Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,54 @@ curl -X PUT http://127.0.0.1:4567/v1/auth/idents/bar-2-user -d '{
 }'
 ```
 
+### Account based Subject Mapping
+
+You can also apply subject mappings to an account.
+
+```
+curl -X PUT http://127.0.0.1:4567/v1/auth/accounts/MappedAccount -d '{
+  "mappings": {
+    "foo": [
+      {
+        "destination": "foo.mapped",
+        "weight": "100%"
+      }
+    ],
+    "bar": [
+      {
+        "destination": "bar.mapped.1",
+        "weight": "50%"
+      },
+      {
+        "destination": "bar.mapped.2",
+        "weight": "50%"
+      }
+    ]
+  }
+}'
+```
+
+Add a user:
+
+```
+curl -X PUT http://127.0.0.1:4567/v1/auth/idents/mapped-account-user -d '{
+  "username": "mapped-account-user",
+  "password": "mapped-account-user-secret",
+  "permissions": "admin",
+  "account": "MappedAccount"
+}'
+```
+
+Messages published to `foo` will be mapped to `foo.mapped` and messages
+published to `bar` will be distributed to `bar.mapped.1` and `bar.mapped.2`
+roughly equally.
+
+Account subject mappings are maintained alongside import and exports, so
+be sure to include existing imports and exports as you add, change, or remove
+subject mappings. 
+
+## Creating Snapshots
+
 We now can create a named snapshot for this setup. Let's create one named `v1`:
 
 ```sh

--- a/api/types.go
+++ b/api/types.go
@@ -122,7 +122,7 @@ type Account struct {
 	// JetStream enables the JS config.
 	JetStream *AccountJetStreamConfig `json:"jetstream,omitempty"`
 
-	// Subject mapping enables remapping subject and paritions
+	// Subject mapping enables remapping subject and partitions
 	Mappings map[string][]*SubjectMap `json:"mappings,omitempty"`
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -100,6 +100,14 @@ type ConfigUser struct {
 	Permissions *Permissions `json:"permissions,omitempty"`
 }
 
+// Subject mapping destination is for mapping subjects globally, by account, or
+// by import.
+type SubjectMap struct {
+	Destination string `json:"destination,omitempty"`
+	Weight      string `json:"weight,omitempty"`
+	Cluster     string `json:"cluster,omitempty"`
+}
+
 // Account with users.
 type Account struct {
 	// Users that belong to the account.
@@ -113,6 +121,9 @@ type Account struct {
 
 	// JetStream enables the JS config.
 	JetStream *AccountJetStreamConfig `json:"jetstream,omitempty"`
+
+	// Subject mapping enables remapping subject and paritions
+	Mappings map[string][]*SubjectMap `json:"mappings,omitempty"`
 }
 
 // AsJSON returns a byte slice of the type.
@@ -150,7 +161,7 @@ type AccountJetStreamConfig struct {
 }
 
 type GlobalJetStream struct {
-	StoreDir string `json:"store_dir,omitempty"`
+	StoreDir         string `json:"store_dir,omitempty"`
 	AccountJetStream `json:",inline"`
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1655,6 +1655,42 @@ func TestAccountsHandler(t *testing.T) {
 			nil,
 			errors.New("Error: Import service subject must not have a wildcard"),
 		},
+		{
+			"create acctmap account with subject mapping",
+			"acctmap",
+			`{
+				"mappings": {
+				 "s1": [
+				  {
+				   "destination": "d1.1",
+				   "weight": "50%",
+				   "cluster": "foo"
+				  },
+				  {
+				   "destination": "d1.2",
+				   "weight": "50%"
+				  }
+				 ],
+				 "s2": [
+				  {
+				   "destination": "d2.1",
+				   "weight": "75%"
+				  },
+				  {
+				   "destination": "d2.2",
+				   "weight": "25%"
+				  }
+				 ]
+				}
+			   }`,
+			&api.Account{
+				Mappings: map[string][]*api.SubjectMap{
+					"s1": {{Destination: "d1.1", Weight: "50%", Cluster: "foo"}, {Destination: "d1.2", Weight: "50%"}},
+					"s2": {{Destination: "d2.1", Weight: "75%"}, {Destination: "d2.2", Weight: "25%"}},
+				},
+			},
+			nil,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			resp, body, err := curl("PUT", host+"/v1/auth/accounts/"+test.account, []byte(test.payload))
@@ -1829,7 +1865,7 @@ func TestAccountsHandler(t *testing.T) {
 			t.Errorf("Expected OK, got: %v", resp.StatusCode)
 		}
 
-		expected := 5
+		expected := 6
 		var got []interface{}
 		if err := json.Unmarshal(body, &got); err != nil {
 			t.Fatal(err)

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -377,6 +377,7 @@ func (s *Server) buildConfigSnapshot(name string) error {
 					Exports:   acc.Exports,
 					Imports:   acc.Imports,
 					JetStream: acc.JetStream,
+					Mappings:  acc.Mappings,
 				}
 				accounts[u.Account] = account
 			}


### PR DESCRIPTION
This adds subject mapping per account that is JSON compatible for the full destination matching, with weights required and clusters optional.  This PR provides full functionality of subject mapping, but does not support shortcuts allowed in direct server configuration.

e.g. 

```json
  "mappings": {
    "foo": [
      {
        "destination": "foo.mapped",
        "weight": "100%"
      }
    ],
    "bar": [
      {
        "destination": "bar.mapped.1",
        "weight": "50%"
      },
      {
        "destination": "bar.mapped.2",
        "weight": "50%"
      }
    ]
  }
```

Note: Supporting the version of `mappings: { "foo" : "bar" }` would add a fair amount of code and custom parsing to the account object. Adding a mapping object under the `AuthConfig` at the top level is unnecessary as one can use the `$G` account and would result in additional custom parsing as well. As discussed with @wallyqs simpler is better in terms of maintenance and often UX.

Resolves #61.