### PR TITLE
fix user merge if empty username

### DIFF
--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -512,7 +512,7 @@ func (s *Server) buildConfigSnapshotV2(snapshotName string) error {
 		for _, u := range users {
 			user := u
 			currentDN, err := ldap.ParseDN(u.Username)
-			if err == nil {
+			if err == nil && u.Username != "" {
 				// Collect valid DNs and find any other matching DN.
 				for _, prevDN := range *dns {
 					if prevDN.dn.RDNsMatch(currentDN) {
@@ -606,7 +606,7 @@ func mergeDuplicateUsers(users []*api.ConfigUser) []*api.ConfigUser {
 	for _, u := range users {
 		user := u
 		currentDN, err := ldap.ParseDN(u.Username)
-		if err == nil {
+		if err == nil && u.Username != "" {
 			// Collect valid DNs and find any other matching DN.
 			match := false
 			for i, prevDN := range dns {


### PR DESCRIPTION
When using NKeys for user authentication:
```
{
  "nkey": "UCM2BMGMMVT5O2LURJIOE6UAZDVI4CPCEDV2XMGVXPBXWHEROD4OWGM4",
  "permissions": "subscriber",
  "account": "default"
}
```

Username/password is not allowed.

When you try to add multiple users with NKeys authentication it merges them into one.

Merge is executed due to how the username value is parsed with `ldap.ParseDN(u.Username)` call. It always results in an empty string if an empty string is passed. As it is considered a valid DN per rfc4514, it executes the code that collects valid DNs and finds any other matching DNs, resulting in an unnecessary user merge when using multiple users with NKeys authentication.

I propose to skip the code that tries to find matching DNs if u.Username is an empty string.